### PR TITLE
Fixed the position of the pop up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.Devfolio_Token }}
+          BRANCH: gh-pages
+          FOLDER: lib
+          CLEAN: true

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -8,7 +8,7 @@ const App = () => (
     style={{ display: "flex", alignItems: "center", flexDirection: "column" }}
   >
     <h1 style={{ marginBottom: "50px" }}>Copy email address to clipboard</h1>
-    <CopyMailTo email="email@domain.com" />
+    <CopyMailTo email="email@domain.com" pos="above" />
   </div>
 );
 

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -25,8 +25,8 @@ const containerBaseStyles: React.CSSProperties = {
   position: "relative",
 };
 
-const tooltipBaseStyles: React.CSSProperties = {
-  bottom: "26px",
+const tooltipBaseStyles = (pos: string): React.CSSProperties => ({
+  [pos === "above" ? "bottom" : "top"]: "26px",
   maxWidth: "fit-content",
   position: "absolute",
   width: "auto",
@@ -41,10 +41,10 @@ const tooltipBaseStyles: React.CSSProperties = {
   padding: "6px 8px",
   borderRadius: "5px",
   opacity: 0,
-  transform: "translateY(-5px)",
+  transform: `translateY(${pos === "above" ? "-5px": "5px"})`,
   visibility: "hidden",
   transition: "all 0.2s ease-in-out",
-};
+});
 
 const toolTipVisibleStyles: React.CSSProperties = {
   opacity: 1,
@@ -60,6 +60,7 @@ const CopyMailTo = ({
   containerStyles = {},
   tooltipStyles = {},
   anchorStyles = {},
+  pos = "above",
 }: {
   email: string;
   children?: React.ReactNode;
@@ -68,6 +69,7 @@ const CopyMailTo = ({
   containerStyles?: React.CSSProperties;
   tooltipStyles?: React.CSSProperties;
   anchorStyles?: React.CSSProperties;
+  pos?: string;
 }): JSX.Element => {
   const [showCopied, setShowCopied] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
@@ -101,10 +103,10 @@ const CopyMailTo = ({
   };
 
   const allTooltipStyles = {
-    ...tooltipBaseStyles,
-    ...tooltipStyles,
-    ...(showTooltip && toolTipVisibleStyles),
-  };
+		...tooltipBaseStyles(pos),
+		...tooltipStyles,
+		...(showTooltip && toolTipVisibleStyles),
+	};
 
   return (
     <span style={allContainerStyles}>


### PR DESCRIPTION
Provided ease of customization to developers. A developer can now specify where to show the tooltip, either on the top or below the email link.

In reference to issue #7 