### PR TITLE
Added tooltip position and action workflow for deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dewanshrawat15-patch* ]
   pull_request:
     branches: [ master ]
 
@@ -18,11 +18,12 @@ jobs:
         run: |
           npm install
           npm run build
+          npm run demo:prod
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.Devfolio_Token }}
           BRANCH: gh-pages
-          FOLDER: lib
+          FOLDER: dist
           CLEAN: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.Devfolio_Token }}
+          BRANCH: gh-pages
+          FOLDER: lib
+          CLEAN: true

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -8,7 +8,7 @@ const App = () => (
     style={{ display: "flex", alignItems: "center", flexDirection: "column" }}
   >
     <h1 style={{ marginBottom: "50px" }}>Copy email address to clipboard</h1>
-    <CopyMailTo email="email@domain.com" pos="above" />
+    <CopyMailTo email="email@domain.com" />
   </div>
 );
 

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -8,7 +8,7 @@ const App = () => (
     style={{ display: "flex", alignItems: "center", flexDirection: "column" }}
   >
     <h1 style={{ marginBottom: "50px" }}>Copy email address to clipboard</h1>
-    <CopyMailTo email="email@domain.com" />
+    <CopyMailTo email="email@domain.com" pos="below" />
   </div>
 );
 

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -8,7 +8,7 @@ const App = () => (
     style={{ display: "flex", alignItems: "center", flexDirection: "column" }}
   >
     <h1 style={{ marginBottom: "50px" }}>Copy email address to clipboard</h1>
-    <CopyMailTo email="email@domain.com" />
+    <CopyMailTo email="email@domain.com" pos="above" />
   </div>
 );
 

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -25,8 +25,8 @@ const containerBaseStyles: React.CSSProperties = {
   position: "relative",
 };
 
-const tooltipBaseStyles = (pos: string): React.CSSProperties => ({
-  [pos === "above" ? "bottom" : "top"]: "26px",
+const tooltipBaseStyles: React.CSSProperties = {
+  bottom: "26px",
   maxWidth: "fit-content",
   position: "absolute",
   width: "auto",
@@ -41,10 +41,10 @@ const tooltipBaseStyles = (pos: string): React.CSSProperties => ({
   padding: "6px 8px",
   borderRadius: "5px",
   opacity: 0,
-  transform: `translateY(${pos === "above" ? "-5px": "5px"})`,
+  transform: "translateY(-5px)",
   visibility: "hidden",
   transition: "all 0.2s ease-in-out",
-});
+};
 
 const toolTipVisibleStyles: React.CSSProperties = {
   opacity: 1,
@@ -60,7 +60,6 @@ const CopyMailTo = ({
   containerStyles = {},
   tooltipStyles = {},
   anchorStyles = {},
-  pos = "above",
 }: {
   email: string;
   children?: React.ReactNode;
@@ -69,7 +68,6 @@ const CopyMailTo = ({
   containerStyles?: React.CSSProperties;
   tooltipStyles?: React.CSSProperties;
   anchorStyles?: React.CSSProperties;
-  pos?: string;
 }): JSX.Element => {
   const [showCopied, setShowCopied] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
@@ -103,10 +101,10 @@ const CopyMailTo = ({
   };
 
   const allTooltipStyles = {
-		...tooltipBaseStyles(pos),
-		...tooltipStyles,
-		...(showTooltip && toolTipVisibleStyles),
-	};
+    ...tooltipBaseStyles,
+    ...tooltipStyles,
+    ...(showTooltip && toolTipVisibleStyles),
+  };
 
   return (
     <span style={allContainerStyles}>

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -25,8 +25,8 @@ const containerBaseStyles: React.CSSProperties = {
   position: "relative",
 };
 
-const tooltipBaseStyles: React.CSSProperties = {
-  bottom: "26px",
+const tooltipBaseStyles = (pos: string): React.CSSProperties => ({
+  [pos === "above" ? "bottom" : "top"]: "26px",
   maxWidth: "fit-content",
   position: "absolute",
   width: "auto",
@@ -41,10 +41,10 @@ const tooltipBaseStyles: React.CSSProperties = {
   padding: "6px 8px",
   borderRadius: "5px",
   opacity: 0,
-  transform: "translateY(-5px)",
+  transform: `translateY(${pos === "above" ? "-5px": "5px"})`,
   visibility: "hidden",
   transition: "all 0.2s ease-in-out",
-};
+});
 
 const toolTipVisibleStyles: React.CSSProperties = {
   opacity: 1,
@@ -60,6 +60,7 @@ const CopyMailTo = ({
   containerStyles = {},
   tooltipStyles = {},
   anchorStyles = {},
+  pos = "above",
 }: {
   email: string;
   children?: React.ReactNode;
@@ -68,6 +69,7 @@ const CopyMailTo = ({
   containerStyles?: React.CSSProperties;
   tooltipStyles?: React.CSSProperties;
   anchorStyles?: React.CSSProperties;
+  pos?: string;
 }): JSX.Element => {
   const [showCopied, setShowCopied] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
@@ -101,10 +103,10 @@ const CopyMailTo = ({
   };
 
   const allTooltipStyles = {
-    ...tooltipBaseStyles,
-    ...tooltipStyles,
-    ...(showTooltip && toolTipVisibleStyles),
-  };
+		...tooltipBaseStyles(pos),
+		...tooltipStyles,
+		...(showTooltip && toolTipVisibleStyles),
+	};
 
   return (
     <span style={allContainerStyles}>


### PR DESCRIPTION
### Added a feature for the tooltip position and used Github Actions

Added the tooltip position and used the suggested Github Actions to build the repository in production and then deploy it to 'gh-pages' branch in the repository. This essentially deploys the repository to Github Pages.

A sample demo can be seen at [here](https://dewanshrawat15.github.io/react-copy-mailto/)

In reference to issues number #7 and #8 

@prateek3255 please let me know your suggestions / views.