### PR TITLE
Tooltip problem solved as specified in issue #60

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -51,7 +51,6 @@ const toolTipVisibleStyles: React.CSSProperties = {
   transform: "none",
   visibility: "visible",
 };
-
 const CopyMailTo = ({
   email,
   children = null,
@@ -71,7 +70,6 @@ const CopyMailTo = ({
 }): JSX.Element => {
   const [showCopied, setShowCopied] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
-
   const copyEmail = (e: MouseEvent) => {
     e.preventDefault();
     copyToClipboard(email);
@@ -79,8 +77,13 @@ const CopyMailTo = ({
     setShowTooltip(true);
   };
 
-  const displayTooltip = () => {
-    setShowTooltip(true);
+  const displayTooltip = () => {  
+    navigator.clipboard.readText().then(clipText=>{
+      console.log("Current clipboard=",clipText);
+      if(clipText!=="email@domain.com")
+      {setShowTooltip(true);}
+    
+    });  
   };
 
   const hideTooltip = () => {
@@ -91,7 +94,7 @@ const CopyMailTo = ({
     if (showCopied) {
       window.setTimeout(() => {
         setShowCopied(false);
-      }, 1000);
+      }, 10000);
     }
   }, [showCopied]);
 


### PR DESCRIPTION
As specified the issue in #60 
The issue was that
1)If the address is already in clipboard then also the 'Copy email address' tooltip was visible which can confuse the user.

The solution which I have proposed is that
1)If the address is not in the clipboard then the 'Copy email address' tooltip will be visible.
2)But If the address is in the clipboard then that 'Copy email address' tooltip will not be visible.

Screenshots:-
1)Initially the clipboard contains whitespace as seen in console so the tooltip is visible. 
![2020-10-04 (14)](https://user-images.githubusercontent.com/48866201/95019501-5f0b7180-0683-11eb-8297-231326999bee.png)

2)Now, the email address is copied to clipboard by clicking on the link
![2020-10-04 (15)](https://user-images.githubusercontent.com/48866201/95019522-7fd3c700-0683-11eb-9b55-9c94259e135c.png)

3)Now, the clipboard contains the email address and as we can see that tooltip is not visible because the address is already in the clipboard.

![2020-10-04 (16)](https://user-images.githubusercontent.com/48866201/95019554-a8f45780-0683-11eb-8dc7-069f8d073d73.png)

So, making this PR for fixing that issue.
@prateek3255 @apollonian 

