### PR TITLE
Fix tooltip text changing after copying, fixes #77

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -83,19 +83,14 @@ const CopyMailTo = ({
     setShowTooltip(true);
   };
 
-  const toggleTooltip = () => {
-    setShowTooltip(prevTooltipState => !prevTooltipState);
-  };
+  const openTooltip = () => {
+    setShowCopied(false);
+    setShowTooltip(true);
+  }
 
-  React.useEffect(() => {
-    let intervalId: number;
-    if (showCopied) {
-      intervalId = window.setTimeout(() => {
-        setShowCopied(false);
-      }, 1000);
-    }
-    return (() => window.clearInterval(intervalId));
-  }, [showCopied]);
+  const closeTooltip = () => {
+    setShowTooltip(false);
+  }
 
   const allContainerStyles = {
     ...containerBaseStyles,
@@ -113,10 +108,10 @@ const CopyMailTo = ({
       <a
         aria-label={defaultTooltip}
         onClick={copyEmail}
-        onMouseOver={toggleTooltip}
-        onMouseOut={toggleTooltip}
-        onFocus={toggleTooltip}
-        onBlur={toggleTooltip}
+        onMouseOver={openTooltip}
+        onMouseOut={closeTooltip}
+        onFocus={openTooltip}
+        onBlur={closeTooltip}
         href={`mailto:${email}`}
         style={anchorStyles}
       >


### PR DESCRIPTION
Before this PR, the text change of the tooltip text was set with setTimeout (1000ms). As reported in #77, if the cursor stayed on top of the email longer than the setTimeout limit, then the default tooltip text would become visible again, and this would be confusing for the user.

I'm including this gif to demonstrate how the behaviour was fixed in this PR.

![2020-10-17 19 22 09](https://user-images.githubusercontent.com/73028165/96347968-21104380-10ae-11eb-9ee8-d14284b467b4.gif)
